### PR TITLE
Use Node version 20.x for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,10 +86,10 @@ jobs:
           go-version: 1.23.1
           cache-dependency-path: |
             ./go.sum
-      - name: Use Node.js 14.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
           cache: "npm"
       - run: npm install
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.23.1
           cache-dependency-path: |
             ./go.sum
-      - name: Set up Node.js
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
           node-version: 20.x


### PR DESCRIPTION
Noticed a typo on the Node version in the dry-run, need to update to 20.x