### PR TITLE
Publish as public package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   "engines": {
     "node": "20"
   },
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts"
+  },
   "scripts": {
     "build:go": "scripts/go-build.sh",
     "build": "tsc && npm run build:go",


### PR DESCRIPTION
The release stage defaults to publishing private, so lets explicitly set this to public.