### PR TITLE
fix(license): Add license to package to appear on NPM registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-semantically-released",
   "description": "A WebAssembly wrapper that provides a convenient way to use the HCL (HashiCorp Configuration Language) library in Node.js.",
   "packageManager": "npm@9.0.0",
+  "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {


### PR DESCRIPTION
The LICENSE file is packaged in the package, but for it to appear on NPM we should add it to the package.json as well.